### PR TITLE
fix: upgrade com.fasterxml.jackson.core:jackson-databind to 2.9.7, 2.8.11.3, 2.7.9.5, 2.6.7.3 (CVE-2018-14718)

### DIFF
--- a/local/workspace/Horosa-Web-55c75c5b088252fbd718afeffa6d5bcb59254a0c/astrostudysrv/boundless/pom.xml
+++ b/local/workspace/Horosa-Web-55c75c5b088252fbd718afeffa6d5bcb59254a0c/astrostudysrv/boundless/pom.xml
@@ -20,7 +20,7 @@
 		<junit.version>4.12</junit.version>
 		<druid.version>1.2.16</druid.version>
 		<httpcomponents.version>4.5.6</httpcomponents.version>
-		<jackson.version>2.9.6</jackson.version>
+		<jackson.version>2.9.7</jackson.version>
 		<gson.version>2.8.5</gson.version>
 		<rabbitmq.version>5.4.1</rabbitmq.version>
 		<kafka.version>2.0.0</kafka.version>


### PR DESCRIPTION
## Summary
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.9.6 to 2.9.7, 2.8.11.3, 2.7.9.5, 2.6.7.3 to fix CVE-2018-14718.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2018-14718 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2018-14718` |
| **File** | `local/workspace/Horosa-Web-55c75c5b088252fbd718afeffa6d5bcb59254a0c/astrostudysrv/boundless/pom.xml` (dependency: `com.fasterxml.jackson.core:jackson-databind`) |
| **Assessment** | Likely exploitable |

**Description**: jackson-databind: arbitrary code execution in slf4j-ext class

## Evidence

**Scanner confirmation**: trivy rule `CVE-2018-14718` flagged this pattern.

## Changes
- `local/workspace/Horosa-Web-55c75c5b088252fbd718afeffa6d5bcb59254a0c/astrostudysrv/boundless/pom.xml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
